### PR TITLE
Change parser to strip out carriage returns from windows .smoke files

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -52,6 +52,7 @@ var parser = {
     parse: function(rawData) {
         var parsedData = [];
 
+        rawData = rawData.replace(/[\r]/g, ''); // Strip out the CR of CRLF ended files
         rawData = rawData.split('\n');
 
         if (rawData.length === 0) {

--- a/test/shisha.spec.js
+++ b/test/shisha.spec.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var mockserver = require('mockserver');
 var shisha = require('../src/index');
+var parser = require('../src/parser');
 var http = require('http');
 var https = require('https');
 var path = require('path');
@@ -15,6 +16,16 @@ describe('Shisha',function(){
 });
 
 describe('Shisha: parser',function(){
+	
+	it('should handle CRLF style Windows line endings', function(){
+
+            var data1 = "url1 200\r\nurl2 404";
+            var data2 = "url1 200\nurl2 404";
+            var parsed1 = parser.parse(data1);
+            var parsed2 = parser.parse(data2);
+            assert.equal(JSON.stringify(parsed1), JSON.stringify(parsed2));
+       });
+	
 	it('should be throw an error if there is no .smoke', function(){
         var f = false;
 


### PR DESCRIPTION
not everyone formats their text files correctly when working on windows. 
this just ensures that the smoke files are parsed correctly without converting status codes from say 200 to 200\r which causes the tests to fail 